### PR TITLE
SUP-1534, Handle double-click scenario for registration page.

### DIFF
--- a/app/account/register/register.controller.js
+++ b/app/account/register/register.controller.js
@@ -67,18 +67,15 @@
         }
       }
       $log.debug('attempting to register user');
-      vm.busyMessage = "Registering..";
       TcAuthService.register(body)
       .then(function(data) {
         $log.debug('registered successfully');
-        vm.busyMessage = CONSTANTS.BUSY_PROGRESS_MESSAGE;
 
         // In the future, go to dashboard
         $state.go('registeredSuccessfully');
       })
       .catch(function(err) {
         $log.error('Error in registering new user: ', err);
-        vm.busyMessage = CONSTANTS.BUSY_PROGRESS_MESSAGE;
       });
     };
 

--- a/app/account/register/register.controller.js
+++ b/app/account/register/register.controller.js
@@ -13,6 +13,7 @@
 
     // Set default for toggle password directive
     vm.defaultPlaceholder = 'Create Password';
+    vm.busyMessage = CONSTANTS.BUSY_PROGRESS_MESSAGE;
 
     // lookup users country
     Helpers.getCountyObjFromIP()
@@ -66,15 +67,18 @@
         }
       }
       $log.debug('attempting to register user');
+      vm.busyMessage = "Registering..";
       TcAuthService.register(body)
       .then(function(data) {
         $log.debug('registered successfully');
+        vm.busyMessage = CONSTANTS.BUSY_PROGRESS_MESSAGE;
 
         // In the future, go to dashboard
         $state.go('registeredSuccessfully');
       })
       .catch(function(err) {
         $log.error('Error in registering new user: ', err);
+        vm.busyMessage = CONSTANTS.BUSY_PROGRESS_MESSAGE;
       });
     };
 

--- a/app/account/register/register.controller.js
+++ b/app/account/register/register.controller.js
@@ -13,7 +13,6 @@
 
     // Set default for toggle password directive
     vm.defaultPlaceholder = 'Create Password';
-    vm.busyDisabled = true;
 
     // lookup users country
     Helpers.getCountyObjFromIP()

--- a/app/account/register/register.jade
+++ b/app/account/register/register.jade
@@ -79,7 +79,7 @@
 
     button(type="submit", busy, busy-disabled="true", ng-disabled="vm.registerForm.$invalid", ng-class="{'enabled-button': vm.registerForm.$valid}") Join Now
       busy-message
-        i.fa.fa-spinner(ng-bind="busyMessage")
+        i.fa.fa-spinner(ng-bind="vm.busyMessage")
 
   section.terms
     p By clicking "JOIN NOW" you agree to Topcoder's

--- a/app/account/register/register.jade
+++ b/app/account/register/register.jade
@@ -79,7 +79,7 @@
 
     button(type="submit", busy, busy-disabled="true", ng-disabled="vm.registerForm.$invalid", ng-class="{'enabled-button': vm.registerForm.$valid}") Join Now
       busy-message
-        i.fa.fa-spinner Processing..
+        i.fa.fa-spinner(ng-bind="busyMessage")
 
   section.terms
     p By clicking "JOIN NOW" you agree to Topcoder's

--- a/app/account/register/register.jade
+++ b/app/account/register/register.jade
@@ -77,9 +77,9 @@
 
         p(ng-class="{ 'has-symbol-or-number': (vm.registerForm.password.$dirty && !vm.registerForm.password.$error.hasSymbolOrNumber) }") At least one number or symbol
 
-    button(type="submit", ng-disabled="vm.registerForm.$invalid", ng-class="{'enabled-button': vm.registerForm.$valid}") Join Now
-      //- busy-message
-      //-   i.fa.fa-spinner Processing...
+    button(type="submit", busy, busy-disabled="true", ng-disabled="vm.registerForm.$invalid", ng-class="{'enabled-button': vm.registerForm.$valid}") Join Now
+      busy-message
+        i.fa.fa-spinner Processing..
 
   section.terms
     p By clicking "JOIN NOW" you agree to Topcoder's

--- a/app/topcoder.constants.js
+++ b/app/topcoder.constants.js
@@ -28,7 +28,7 @@ angular.module("CONSTANTS", [])
 	"STATE_LOADING": "loading",
 	"STATE_ERROR": "error",
 	"STATE_READY": "ready",
-	"BUSY_PROGRESS_MESSAGE" : "Processing.."
+	"BUSY_PROGRESS_MESSAGE": "Processing.."
 })
 
 ;

--- a/app/topcoder.constants.js
+++ b/app/topcoder.constants.js
@@ -27,7 +27,8 @@ angular.module("CONSTANTS", [])
 	"EVENT_PROFILE_UPDATED": "profile_updated",
 	"STATE_LOADING": "loading",
 	"STATE_ERROR": "error",
-	"STATE_READY": "ready"
+	"STATE_READY": "ready",
+	"BUSY_PROGRESS_MESSAGE" : "Processing.."
 })
 
 ;

--- a/assets/css/account/account.scss
+++ b/assets/css/account/account.scss
@@ -44,6 +44,10 @@
     &.enabled-button {
       @include ui-enabled-button;
     }
+
+    &[disabled] {
+      @include ui-disabled-button;
+    }
   }
 
   // Form stylings

--- a/assets/css/partials/_mixins.scss
+++ b/assets/css/partials/_mixins.scss
@@ -271,6 +271,11 @@
   cursor: pointer;
 }
 
+@mixin ui-disabled-button {
+  background-color: $ui-disabled-button-blue;
+  cursor: default;
+}
+
 @mixin ui-track-button {
   border: 2px solid $ui-enabled-button-blue;
   color: $ui-enabled-button-blue;

--- a/config.js
+++ b/config.js
@@ -32,7 +32,9 @@ module.exports = function() {
 
         STATE_LOADING: 'loading',
         STATE_ERROR: 'error',
-        STATE_READY: 'ready'
+        STATE_READY: 'ready',
+
+        BUSY_PROGRESS_MESSAGE : 'Processing..'
 
       }
     },
@@ -68,7 +70,9 @@ module.exports = function() {
 
         STATE_LOADING: 'loading',
         STATE_ERROR: 'error',
-        STATE_READY: 'ready'
+        STATE_READY: 'ready',
+
+        BUSY_PROGRESS_MESSAGE : 'Processing..'
 
       }
     },
@@ -104,7 +108,9 @@ module.exports = function() {
 
         STATE_LOADING: 'loading',
         STATE_ERROR: 'error',
-        STATE_READY: 'ready'
+        STATE_READY: 'ready',
+
+        BUSY_PROGRESS_MESSAGE : 'Processing..'
 
       }
     }


### PR DESCRIPTION
Reenabled ng-busy plugin with Join Now button. It is working fine with rejected promises too.

@parthshah fyi

I checked it is working fine with rejected promise as well.
Also, note that I have used dynamic message for busy state to differentiate between background ajax calls for validation and actual call for registration process.

EDIT: I just noted that dynamic message for busy state is applying late in the event processing, which causes the original message "Processing .." to be displayed first and then suddenly change to "Registering..". I would try to fix it, otherwise I would revert back to fixed busy message as earlier. :)