### PR TITLE
adding support for api versions in jwtinterceptor

### DIFF
--- a/app/services/jwtInterceptor.service.js
+++ b/app/services/jwtInterceptor.service.js
@@ -18,11 +18,11 @@
         return null;
 
       var haveItAddItEndpoints = [
-        { method: 'GET', url: '\/v3\/challenges'},
+        { method: 'GET', url: '\/v3[\d.\-A-Za-z]*\/challenges'},
         { method: 'GET', url: '\/v2\/challenges'},
 
         // matchs everything besides /v3/members/{handle}/financial
-        { method: 'GET', url: '\/v3\/members\/\\w+\/(?!financial)\\w*'}
+        { method: 'GET', url: '\/v3[\d.\-A-Za-z]*\/members\/\\w+\/(?!financial)\\w*'}
       ];
 
       for (var i = 0; i < haveItAddItEndpoints.length; i++) {

--- a/app/services/jwtInterceptor.service.spec.js
+++ b/app/services/jwtInterceptor.service.spec.js
@@ -64,6 +64,15 @@ describe('JWT Interceptor Service', function() {
       expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
     });
 
+    it("should not add token for /v3.0.0-beta/challenges", function() {
+      var config = {
+        method: "get",
+        url: apiUrl + "/v3.0.0-beta/challenges/?filter=status%3Dactive"
+      };
+      expect(service.getToken(config)).to.not.exist;
+      expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
+    });
+
     it("should redirect to login page for other endpoints", function() {
       var config = {
         method: "get",
@@ -74,136 +83,19 @@ describe('JWT Interceptor Service', function() {
       expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
     });
 
-    afterEach(function() {
-      TcAuthService.isAuthenticated.restore();
-    });
-  });
-
-/*
-  describe("for authenticated users", function() {
-    beforeEach(function() {
-      bard.inject(this, 'TcAuthService');
-      sinon.stub(TcAuthService, 'isAuthenticated').returns(true);
-      $rootScope.$apply();
-    });
-
-    describe(" with an valid token ", function() {
-      beforeEach(function() {
-        bard.inject(this, 'jwtHelper');
-        sinon.stub(jwtHelper, 'isTokenExpired').returns(false);
-      });
-
-      afterEach(function() {
-        jwtHelper.isTokenExpired.restore();
-      });
-
-      it("should return v2 token for /v3/members/test/stats", function() {
-        var config = {
-          method: "get",
-          url: apiUrl + "/v3/members/test/stats"
-        };
-        expect(service.getToken(config)).to.equal("v2Token");
-        expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
-        expect(jwtHelper.isTokenExpired).to.be.have.been.calledOnce;
-      });
-
-      it("should return v3 token for /v3/users/123", function() {
-        var config = {
-          method: "post",
-          url: apiUrl + "/v3/users/123"
-        };
-        expect(service.getToken(config)).to.equal('v3Token');
-        expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
-        expect(jwtHelper.isTokenExpired).to.be.have.been.calledOnce;
-      });
-
-      it("should return v2 token for /v2/badges", function() {
-        var config = {
-          method: "GET",
-          url: apiUrl + "/v2/badges"
-        };
-        expect(service.getToken(config)).to.equal('v2Token');
-        expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
-        expect(jwtHelper.isTokenExpired).to.be.have.been.calledOnce;
-      });
-    });
-
-    describe(" with an invalid token and successful refreshToken call", function() {
-      beforeEach(function() {
-        bard.inject(this, 'jwtHelper', 'AuthTokenService', '$q');
-        sinon.stub(jwtHelper, 'isTokenExpired').returns(true);
-        sinon.stub(AuthTokenService, 'refreshToken', function(idToken) {
-          var deferred = $q.defer();
-          var resp = {
-            data: {
-              result: {
-                content: {
-                  token: "newV3Token"
-                }
-              }
-            }
-          };
-
-          deferred.resolve(resp);
-          return deferred.promise;
-        });
-
-      });
-      afterEach(function() {
-        jwtHelper.isTokenExpired.restore();
-        AuthTokenService.refreshToken.restore();
-      });
-
-      it("should retrieve a valid refresh token", function() {
-        var config = {
-          method: "get",
-          url: apiUrl + "/v3/users/123"
-        };
-        var retPromise = service.getToken(config);
-        $rootScope.$digest();
-        expect(retPromise.$$state.value).to.equal("newV3Token");
-        expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
-        expect(jwtHelper.isTokenExpired).to.be.have.been.calledOnce;
-        expect(AuthTokenService.refreshToken).to.be.have.been.calledWith("v3Token");
-        expect(AuthTokenService.setV3Token).to.be.have.been.calledWith("newV3Token");
-      });
-    });
-
-    describe("with an invalid token and un-successful refreshToken call", function() {
-      beforeEach(function() {
-        bard.inject(this, 'jwtHelper', 'AuthTokenService', '$q');
-        sinon.stub(jwtHelper, 'isTokenExpired').returns(true);
-        sinon.stub(AuthTokenService, 'refreshToken', function(idToken) {
-          var deferred = $q.defer();
-          deferred.reject("bad request");
-          return deferred.promise;
-        });
-      });
-
-      afterEach(function() {
-        jwtHelper.isTokenExpired.restore();
-        AuthTokenService.refreshToken.restore();
-      });
-
-      it("should redirect to login", function() {
-        var config = {
-          method: "get",
-          url: apiUrl + "/v3/users/123"
-        };
-        var retPromise = service.getToken(config);
-        $rootScope.$digest();
-        expect(retPromise.$$state.value).to.be.null;
-        expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
-        expect(jwtHelper.isTokenExpired).to.be.have.been.calledOnce;
-        expect(AuthTokenService.refreshToken).to.be.have.been.calledWith("v3Token");
-        expect($state.go).to.be.have.been.calledWith('login');
-      });
+    it("should redirect to login page for other endpoints", function() {
+      var config = {
+        method: "get",
+        url: apiUrl + "/v3.0.0-BETA/members/test"
+      };
+      service.getToken(config);
+      expect($state.go).to.be.have.been.calledWith('login');
+      expect(TcAuthService.isAuthenticated).to.be.have.been.calledOnce;
     });
 
     afterEach(function() {
       TcAuthService.isAuthenticated.restore();
     });
   });
-*/
 
 });


### PR DESCRIPTION
Topcoder-app needs to support semver api versioning. This change enables jwtinterceptor to handle major minor versions.