### PR TITLE
SUP-2138, Profile-->User/Handle name is missing for 'BitBucket' external account.

### DIFF
--- a/app/directives/external-account/external-link-data.directive.jade
+++ b/app/directives/external-account/external-link-data.directive.jade
@@ -65,7 +65,7 @@
             .key likes
 
       div(ng-switch-when="bitbucket")
-        .handle {{account.data.username}}
+        .handle {{account.data.handle}}
 
         .pending(ng-show="account.data.status === 'PENDING'")
           p Loading data. This will take a few minutes.


### PR DESCRIPTION
-- Fixed