### PR TITLE
SUP-1922, Stack overflow should have both side space on account card.

### DIFF
--- a/assets/css/directives/external-account.scss
+++ b/assets/css/directives/external-account.scss
@@ -76,6 +76,7 @@
       text-align: center;
       text-transform: uppercase;
       color: $accent-gray;
+      padding: 0 10px;
     }
   }
 


### PR DESCRIPTION
-- Adding 10px padding from left and right which causes Stack Overflow to wrap into two lines.