### PR TITLE
SUP-2286, [Registration] Skill picker issue

### DIFF
--- a/app/directives/busy-button/busy-button.directive.js
+++ b/app/directives/busy-button/busy-button.directive.js
@@ -23,9 +23,9 @@
               scope);
             element.attr('disabled', true).html('').append(busyMessageHtml);
           } else {
-            // remove the disabled attribute only if either element does not have ng-disabled set
+            // remove the disabled attribute only if either element does not have disabled set
             // or it evaluates to false
-            if (!attr.ngDisabled || !$parse(attr.ngDisabled)) {
+            if (!attrs.disabled) {
               element.removeAttr('disabled').html(scope.originalContent);
             }
           }


### PR DESCRIPTION
-- Fixed issue with tc-busy directive which was causing the edit profile save button to show spinning always.

@parthshah it was my bad. I don't know it worked yesterday night for me. It seems even after disabling the cache, it loads scripts from cache on my local. :(
Anyways, can you please take a look and suggest if I am still missing something here.