### PR TITLE
SUP-2311, Add generic error message when something fails while linking/unlinking the external account

### DIFF
--- a/app/directives/external-account/external-account.directive.js
+++ b/app/directives/external-account/external-account.directive.js
@@ -76,13 +76,13 @@
                 toaster.pop('error', "Whoops!",
                   String.supplant(
                     "This {provider} account is linked to another account. \
-                    If you think this is an error please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>.",
+                    If you think this is an error please contact <a href=\"mailTo:support@topcoder.com\">support@topcoder.com</a>.",
                     {provider: provider.displayName }
                   )
                 );
               } else {
                 $log.error("Fatal Error: _link: " + resp.msg);
-                toaster.pop('error', "Whoops!", "Sorry, we are unable to add your account right now. Please try again later. If the problem persists, please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>.");
+                toaster.pop('error', "Whoops!", "Sorry, we are unable to add your account right now. Please try again later. If the problem persists, please contact <a href=\"mailTo:support@topcoder.com\">support@topcoder.com</a>.");
               }
             });
           }
@@ -108,10 +108,10 @@
               var msg = resp.msg;
               if (resp.status === 'SOCIAL_PROFILE_NOT_EXIST') {
                 $log.info("Social profile not linked to account");
-                msg = "{provider} account is not linked to your account. If you think this is an error please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>.";
+                msg = "{provider} account is not linked to your account. If you think this is an error please contact <a href=\"mailTo:support@topcoder.com\">support@topcoder.com</a>.";
               } else {
                 $log.error("Fatal error: _unlink: " + msg);
-                msg = "Sorry! We are unable to unlink your {provider} account. If problem persists, please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>";
+                msg = "Sorry! We are unable to unlink your {provider} account. If problem persists, please contact <a href=\"mailTo:support@topcoder.com\">support@topcoder.com</a>";
               }
               toaster.pop('error', "Whoops!", String.supplant(msg, {provider: provider.displayName }));
             });

--- a/app/directives/external-account/external-account.directive.js
+++ b/app/directives/external-account/external-account.directive.js
@@ -80,6 +80,9 @@
                     {provider: provider.displayName }
                   )
                 );
+              } else {
+                $log.error("Fatal Error: _link: " + resp.msg);
+                toaster.pop('error', "Whoops!", "Sorry, we are unable to add your account right now. Please try again later. If the problem persists, please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>.");
               }
             });
           }
@@ -107,7 +110,7 @@
                 $log.info("Social profile not linked to account");
                 msg = "{provider} account is not linked to your account. If you think this is an error please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>.";
               } else {
-                $log.info("Fatal error: " + msg);
+                $log.error("Fatal error: _unlink: " + msg);
                 msg = "Sorry! We are unable to unlink your {provider} account. If problem persists, please contact <a href=\"mailTo:support@.appirio.com\">support@apprio.com</a>";
               }
               toaster.pop('error', "Whoops!", String.supplant(msg, {provider: provider.displayName }));

--- a/app/services/externalAccounts.service.js
+++ b/app/services/externalAccounts.service.js
@@ -58,12 +58,10 @@
         })
         .catch(function(resp) {
           $log.error("Error unlinking account: " + resp.data.result.content);
-          var status = resp.status;
+          var status = "FATAL_ERROR";
           var msg = resp.data.result.content;
-          if (resp.status = 404) {
+          if (resp.status === 404) {
             status = "SOCIAL_PROFILE_NOT_EXIST";
-          } else {
-            status = "FATAL_ERROR"
           }
           $reject({
             status: status,
@@ -113,9 +111,13 @@
                   });
                 })
                 .catch(function(resp) {
+                  var errorStatus = "FATAL_ERROR";
                   $log.error("Error linking account: " + resp.data.result.content);
+                  if (resp.data.result && resp.data.result.status === 400) {
+                    errorStatus = "SOCIAL_PROFILE_ALREADY_EXISTS";
+                  }
                   reject({
-                    status: "SOCIAL_PROFILE_ALREADY_EXISTS",
+                    status: errorStatus,
                     msg: resp.data.result.content
                   });
                 });


### PR DESCRIPTION
-- Added generic error message when anything bad happens with link/unlink calls.

@parthshah can you please quickly review it? Please I haven't wrote new tests for validating these changes because there no unit tests for the externalAccountService and that service needs some refactoring around calling the end point for adding the social profile. Further, I guess, we already have some major refactoring around external accounts, so it would be better to test it completely after those are in dev.