### PR TITLE
SUP-2398, Skill Picker-->'Done' button is getting enabled for fraction of second after clicking on to done the informations.

### DIFF
--- a/app/skill-picker/skill-picker.controller.js
+++ b/app/skill-picker/skill-picker.controller.js
@@ -15,6 +15,7 @@
     vm.toggleSkill = toggleSkill;
     vm.tracks = {};
     vm.mySkills = [];
+    vm.disableDoneButton = false;
     ///////
     activate();
 
@@ -57,6 +58,7 @@
               .then(function(resp) {
                 vm.saving = false;
                 toaster.pop('success', "Success!", "Your skills have been updated.");
+                vm.disableDoneButton = true;
                 $state.go('dashboard');
               })
               .catch(function(data) {
@@ -66,6 +68,7 @@
           } else {
             vm.saving = false;
             toaster.pop('success', "Success!", "Your skills have been updated.");
+            vm.disableDoneButton = true;
             $state.go('dashboard');
           }
 

--- a/app/skill-picker/skill-picker.jade
+++ b/app/skill-picker/skill-picker.jade
@@ -51,4 +51,4 @@
     type="button",
     tc-busy-button, tc-busy-when="vm.saving",
     ng-click="vm.submitSkills()",
-    ng-disabled="!vm.tracks.DESIGN && !vm.tracks.DEVELOP && !vm.tracks.DATA_SCIENCE") Done
+    ng-disabled="vm.disableDoneButton || (!vm.tracks.DESIGN && !vm.tracks.DEVELOP && !vm.tracks.DATA_SCIENCE)") Done


### PR DESCRIPTION
-- Disabled the button as soon as the API calls returns success so that it does not enabled while browser is trying to navigate to dashboard. However, there is some css issue in disabled state of button with tc-
busy directive.

@vic-appirio @nlitwin can you please have a look at the css issue? Basically, it is showing a blue bar after the "Done" text in the button when the button get disabled after busy state. It seems it is a bug with tc-btn-l class because if I change the button class to be tc-btn-m, it does not show that blue bar.

cc: @parthshah 