### PR TITLE
SUP-2839, Profile: # of wins in summary does not match winning challenges shown on Profile

### DIFF
--- a/app/directives/challenge-tile/challenge-tile.jade
+++ b/app/directives/challenge-tile/challenge-tile.jade
@@ -2,7 +2,8 @@
   .active-challenge(ng-show="challenge.status === 'ACTIVE'")
 
     header
-      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}") #[span {{challenge.name}}]
+      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}", ng-show="!challenge.isPrivate") #[span {{challenge.name}}]
+      span.name(title="{{challenge.name}}", ng-show="challenge.isPrivate") {{challenge.name}}
 
       p.subtrack-color {{challenge.subTrack | underscoreStrip}}
 
@@ -37,7 +38,8 @@
     ng-switch="challenge.track")
 
     header
-      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}") {{challenge.name}}
+      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}", ng-show="!challenge.isPrivate") #[span {{challenge.name}}]
+      span.name(title="{{challenge.name}}", ng-show="challenge.isPrivate") {{challenge.name}}
 
       p.subtrack-color {{challenge.subTrack | underscoreStrip}}
 
@@ -78,7 +80,8 @@
   .active-challenge(ng-show="challenge.status === 'ACTIVE'")
 
     header
-      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}") {{challenge.name}}
+      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}", ng-show="!challenge.isPrivate") #[span {{challenge.name}}]
+      span.name(title="{{challenge.name}}", ng-show="challenge.isPrivate") {{challenge.name}}
       
       p.subtrack-color {{challenge.subTrack | underscoreStrip}}
 
@@ -107,7 +110,8 @@
     ng-switch="challenge.track")
 
     header
-      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}") {{challenge.name}}
+      a.name(ng-href="{{challenge|challengeLinks:'detail'}}", title="{{challenge.name}}", ng-show="!challenge.isPrivate") #[span {{challenge.name}}]
+      span.name(title="{{challenge.name}}", ng-show="challenge.isPrivate") {{challenge.name}}
 
       p.subtrack-color {{challenge.subTrack | underscoreStrip}}
 

--- a/assets/css/directives/challenge-tile.scss
+++ b/assets/css/directives/challenge-tile.scss
@@ -71,7 +71,8 @@ challenge-tile .challenge.tile-view {
     justify-content: space-between;
     padding: 5px 10px;
 
-    a.name {
+    a.name,
+    span.name {
       display: block;
       @include font-with-weight('Sofia Pro', 500);
       font-size: 12px;
@@ -396,7 +397,8 @@ challenge-tile .challenge.list-view {
       padding: 0 30px;
     }
 
-    a.name {
+    a.name,
+    span.name {
       display: block;
       @include font-with-weight('Sofia Pro', 500);
       font-size: 12px;


### PR DESCRIPTION
-- Removed hyper link for challenge for invite-only challenge.

@parthshah @nlitwin I have added new DOM element instead of removing the href attribute dynamically for the challenge name hyperlink. I did this because semantically, when it is not supposed to be a hyperlink, we should not use <a>. If you guys has any reason otherwise, please let me know, I can incorporate them. :)