### PR TITLE
Replace angucomplete-alt with react-select component

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -50,6 +50,7 @@ requireContextFiles(require.context('./', true, /^(?:(?!\.spec\.js$).)*\.js$/igm
 
 // Some ordering is needed for right cascading of styles
 // TODO: each module requires the CSS it needs and we delete this list
+require('../assets/css/vendors/reactselect.scss')
 require('../assets/css/vendors/introjs.scss')
 require('../assets/css/vendors/angucomplete.scss')
 require('../assets/css/topcoder.scss')

--- a/app/settings/edit-profile/edit-profile.controller.js
+++ b/app/settings/edit-profile/edit-profile.controller.js
@@ -97,6 +97,7 @@ import _ from 'lodash'
     }
 
     function updateCountry(countryObj) {
+      vm.editProfile.$setDirty()
       var countryCode = _.get(countryObj, 'alpha3', undefined)
       vm.userData.competitionCountryCode = countryCode
       vm.isValidCountry = _.isUndefined(countryCode) ? false : true

--- a/app/settings/edit-profile/edit-profile.controller.js
+++ b/app/settings/edit-profile/edit-profile.controller.js
@@ -97,6 +97,12 @@ import _ from 'lodash'
     }
 
     function updateCountry(countryObj) {
+      // Hitting backspace sends an empty array as the value instead of {} or null
+      if (Array.isArray(countryObj)) {
+        vm.countryObj = null
+        return
+      }
+      
       vm.editProfile.$setDirty()
       var countryCode = _.get(countryObj, 'alpha3', undefined)
       vm.userData.competitionCountryCode = countryCode

--- a/app/settings/edit-profile/edit-profile.jade
+++ b/app/settings/edit-profile/edit-profile.jade
@@ -36,7 +36,8 @@
             match-prop="'name'",
             input-props="{'id':'countryId'}",
             label-key="'name'",
-            value-key="'name'"
+            value-key="'name'",
+            clearable="false"
           )
           span.error-message(ng-if="!vm.isValidCountry") This is a required field
 
@@ -56,8 +57,13 @@
         track-toggle(tracks="vm.tracks")
 
     .save-section
-      button.tc-btn.tc-btn-primary.tc-btn-wide(ng-show="!(vm.editProfile.$invalid || vm.editProfile.$pristine)", type="submit", tc-busy-button, tc-busy-when="vm.profileFormProcessing" ng-disabled="vm.editProfile.$invalid || vm.editProfile.$pristine", ng-class="{' ': vm.editProfile.$valid, 'disabled': disabled}") Save
-      button.tc-btn.tc-btn-secondary.tc-btn-wide(ng-show="vm.editProfile.$invalid || vm.editProfile.$pristine", type="button", disabled="disabled") Save
+      button.tc-btn.tc-btn-primary.tc-btn-wide(
+        type="submit",
+        tc-busy-button,
+        tc-busy-when="vm.profileFormProcessing",
+        ng-disabled="vm.editProfile.$invalid || vm.editProfile.$pristine",
+        ng-class="{'disabled': disabled}"
+      ) Save
 
   .settings-section.skills
     .section-info
@@ -75,7 +81,8 @@
         name="'skill-input'",
         input-props="{'id':'tagId'}",
         label-key="'name'",
-        value-key="'name'"
+        value-key="'name'",
+        clearable="false"
         )
 
       .list

--- a/app/settings/edit-profile/edit-profile.jade
+++ b/app/settings/edit-profile/edit-profile.jade
@@ -61,7 +61,7 @@
         type="submit",
         tc-busy-button,
         tc-busy-when="vm.profileFormProcessing",
-        ng-disabled="vm.editProfile.$invalid || vm.editProfile.$pristine",
+        ng-disabled="!vm.isValidCountry || !vm.countryObj || vm.editProfile.$invalid || vm.editProfile.$pristine",
         ng-class="{'disabled': disabled}"
       ) Save
 

--- a/assets/css/settings/edit-profile.scss
+++ b/assets/css/settings/edit-profile.scss
@@ -31,7 +31,6 @@
   }
 
   .description {
-
     input[name="description"] {
       margin-bottom: 5px;
 
@@ -149,6 +148,10 @@
     margin-bottom: 30px;
   }
 
+}
+
+.skills dropdown {
+  margin-top: 5px;
 }
 
 dropdown {

--- a/assets/css/settings/edit-profile.scss
+++ b/assets/css/settings/edit-profile.scss
@@ -147,7 +147,6 @@
   .existing-links {
     margin-bottom: 30px;
   }
-
 }
 
 .skills dropdown {

--- a/assets/css/settings/edit-profile.scss
+++ b/assets/css/settings/edit-profile.scss
@@ -154,25 +154,6 @@
   margin-top: 5px;
 }
 
-dropdown {
-  .is-open {
-    > .Select-control {
-      border-color: #0096FF;
-    }
-  }
-
-  .Select-input {
-    input {
-      border-width: 0;
-      padding: 0;
-      &:focus {
-        border-width: 0;
-        box-shadow: none;
-      }
-    }
-  }
-}
-
 .links.settings-section {
   border-bottom: none;
 }

--- a/assets/css/vendors/reactselect.scss
+++ b/assets/css/vendors/reactselect.scss
@@ -1,0 +1,34 @@
+@import 'topcoder/tc-includes';
+
+dropdown .Select {
+  // Override default style guide transition to remove flickering
+  input {
+    transition: all 0s;
+  }
+
+  .is-open {
+    > .Select-control {
+      border-color: #0096FF;
+    }
+  }
+
+  .Select-input {
+    input {
+      height: 34px;
+      margin: 0;
+      padding: 0;
+      background: none transparent;
+      border-radius: 0;
+      border: 0 none;
+      box-shadow: none;
+      cursor: default;
+      line-height: 34px;
+      font-size: 16px;
+
+      &:focus {
+        border-width: 0;
+        box-shadow: none;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Modified Pull Request (original: https://github.com/appirio-tech/topcoder-app/pull/727) for Issue https://github.com/appirio-tech/topcoder-app/issues/684

Replace country and skill dropdowns with react-select components.

@Colinh84, I added a few changes to your PR:
 - CSS to add margin-top for skills dropdown
 - Set `clearable: false` on the dropdowns
 - Set the form to dirty when changing the country
 - Removed legacy code: redundant disabled button
 - Fixed weird flickering from inherited style guide CSS, especially line-height and transition
 - Disable Save button on invalid `vm.countryObject`
 - Move dropdown styles to vendor CSS file in `assets/css/vendors`
