### PR TITLE
Replace URL %20 to dash

### DIFF
--- a/app/services/nav.service.js
+++ b/app/services/nav.service.js
@@ -26,7 +26,7 @@ import angular from 'angular'
           { 'href': '/community/design/', 'text': 'DESIGN', 'icon': require('../../assets/images/nav/book-design.svg') },
           { 'href': '/community/development/', 'text': 'DEVELOPMENT', 'icon': require('../../assets/images/nav/book-develop.svg') },
           { 'href': '/community/data-science/', 'text': 'DATA SCIENCE', 'icon': require('../../assets/images/nav/book-data.svg') },
-          { 'href': '/community/competitive%20programming/', 'text': 'COMPETITIVE PROGRAMMING', 'icon': require('../../assets/images/nav/book-cp.svg') }
+          { 'href': '/community/competitive-programming/', 'text': 'COMPETITIVE PROGRAMMING', 'icon': require('../../assets/images/nav/book-cp.svg') }
       ],
       'community': [
           { 'sref': 'community.members', 'text': 'OVERVIEW', 'icon': require('../../assets/images/nav/members.svg') },

--- a/app/sitemap/sitemap.jade
+++ b/app/sitemap/sitemap.jade
@@ -27,7 +27,7 @@
         li 
           a(href="/community/data-science") Data Science
         li 
-          a(href="/community/competitive programming") Competitive Programming
+          a(href="/community/competitive-programming") Competitive Programming
               
     section.sitemap-nav
       h2.sitemap-header Community


### PR DESCRIPTION
This is the submission to the issue #944.

The link seems to only appear in the `topcoder-app` site and results from `app/services/nav.service.js` and `app/sitemap/sitemap.jade`. The changes should fix the issue in all instances.