### PR TITLE
Asana Task#251570416879588, Add IBM Cognitive opt-in to Skill Picker upon account activation and preferences page

### DIFF
--- a/app/skill-picker/skill-picker.controller.js
+++ b/app/skill-picker/skill-picker.controller.js
@@ -11,9 +11,9 @@ import _ from 'lodash'
   function SkillPickerController($scope, CONSTANTS, ProfileService, $state, userProfile, featuredSkills, logger, toaster, MemberCertService, $q) {
     var vm = this
     vm.ASSET_PREFIX = CONSTANTS.ASSET_PREFIX
-    vm.IOS_PROGRAM_ID = CONSTANTS.SWIFT_PROGRAM_ID
-    vm.PREDIX_PROGRAM_ID = CONSTANTS.PREDIX_PROGRAM_ID
-    vm.IBM_COGNITIVE_PROGRAM_ID = CONSTANTS.IBM_COGNITIVE_PROGRAM_ID
+    vm.IOS_PROGRAM_ID = parseInt(CONSTANTS.SWIFT_PROGRAM_ID)
+    vm.PREDIX_PROGRAM_ID = parseInt(CONSTANTS.PREDIX_PROGRAM_ID)
+    vm.IBM_COGNITIVE_PROGRAM_ID = parseInt(CONSTANTS.IBM_COGNITIVE_PROGRAM_ID)
     vm.submitSkills = submitSkills
     vm.featuredSkills = featuredSkills
     vm.userId = userProfile.userId


### PR DESCRIPTION
-- Fix for the issue where subscribed communities was visible on skill picker.

@ajefts fyi, Fixed the issue I mentioned over slack, after deployment on Friday (Jan 27, 2017). If we need to apply it asap, I can created hotfix instead of regular fix.