### PR TITLE
Fix for issue #1003 Color of the Complete Appeals button

### DIFF
--- a/app/directives/challenge-tile/challenge-tile.jade
+++ b/app/directives/challenge-tile/challenge-tile.jade
@@ -22,7 +22,7 @@
         .phase-action(ng-show="challenge.userAction", ng-switch="challenge.userAction")
           a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Submit", ng-href="{{challenge|challengeLinks:'submit'}}") Submit
           a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'viewScorecards'}}") View Scorecards
-          a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'completeAppeals'}}") Complete Appeals
+          a.tc-btn.tc-btn-s.tc-btn-wide.btn-danger.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'completeAppeals'}}") Complete Appeals
 
           .submitted(ng-switch-when="Submitted") Submitted
 
@@ -100,7 +100,7 @@
       .phase-action(ng-switch="challenge.userAction")
         a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Submit", ng-href="{{challenge|challengeLinks:'submit'}}") Submit
         a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'viewScorecards'}}") View Scorecards
-        a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'completeAppeals'}}") Complete Appeals
+        a.tc-btn.tc-btn-s.tc-btn-wide.btn-danger.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'completeAppeals'}}") Complete Appeals
 
         .submitted(ng-switch-when="Submitted") Submitted
 

--- a/assets/css/directives/challenge-tile.scss
+++ b/assets/css/directives/challenge-tile.scss
@@ -248,6 +248,22 @@ challenge-tile .challenge.tile-view {
         .submit {
           margin: 12px;
           display: block;
+
+          &.btn-danger {
+            color: #e66e66;
+            background-color: $white;
+            border-color: #e66e66;
+
+            &:hover {
+              background-color: #e66e66;
+              color: $white;
+            }
+
+            &:active {
+              background-color: #e0493e;
+              box-shadow: inset 0px 1px 1px 0px rgba(0,0,0,0.30);
+            }
+          }
         }
 
         .submitted {
@@ -508,6 +524,22 @@ challenge-tile .challenge.list-view {
       .submit {
         display: block;
         margin: 6px 0;
+
+        &.btn-danger {
+          color: #e66e66;
+          background-color: $white;
+          border-color: #e66e66;
+
+          &:hover {
+            background-color: #e66e66;
+            color: $white;
+          }
+
+          &:active {
+            background-color: #e0493e;
+            box-shadow: inset 0px 1px 1px 0px rgba(0,0,0,0.30);
+          }
+        }
       }
 
       .submitted {


### PR DESCRIPTION
The color of the complete appeals color has been changed.
A new class btn-danger has been added which changes the styling color
of the button to #e66 as requested. Also hover and active states are supported
To test just modify file challenge-tile.jade so the Complete Appeals buttons
appears.