### PR TITLE
Fix for issue #1083 Complete Appeals shown only when Submitter role p…

### DIFF
--- a/app/directives/challenge-tile/challenge-tile.jade
+++ b/app/directives/challenge-tile/challenge-tile.jade
@@ -20,10 +20,10 @@
         .stalled-challenge(ng-hide="challenge.userCurrentPhaseEndTime") This challenge is currently paused.
 
         .phase-action(ng-show="challenge.userAction", ng-switch="challenge.userAction")
-          a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Submit", ng-href="{{challenge|challengeLinks:'submit'}}") Submit
+          a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Submit", ng-href="{{challenge|challengeLinks:'submit'}}") Submit 
           a.tc-btn.tc-btn-s.tc-btn-wide.btn-danger.submit(ng-switch-when="Submit", ng-href="{{challenge|challengeLinks:'unRegister'}}") Unregister
           a.tc-btn.tc-btn-s.tc-btn-wide.tc-btn-ghost.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'viewScorecards'}}") View Scorecards
-          a.tc-btn.tc-btn-s.tc-btn-wide.btn-danger.submit(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'completeAppeals'}}") Complete Appeals
+          a.tc-btn.tc-btn-s.tc-btn-wide.btn-danger.submit(ng-if="challenge.isSubmitter")(ng-switch-when="Appeal", ng-href="{{challenge|challengeLinks:'completeAppeals'}}") Complete Appeals
 
           .submitted(ng-switch-when="Submitted") Submitted
 

--- a/app/services/challenge.service.js
+++ b/app/services/challenge.service.js
@@ -67,6 +67,7 @@ import moment from 'moment'
         challenge.userCurrentPhase = 'Stalled'
         challenge.userCurrentPhaseEndTime = null
         challenge.userAction = null
+        challenge.isSubmitter = false        
 
         if (phases && phases.length) {
           hasCurrentPhase = true
@@ -96,6 +97,9 @@ import moment from 'moment'
               if (roles && roles.length > 0) {
                 var submitterRole = _.findIndex(roles, function(role) {
                   var lRole = role.toLowerCase()
+                  if (lRole === 'submitter') {
+                    challenge.isSubmitter = true
+                  }
                   return lRole === 'submitter'
                 })
                 if (submitterRole === -1) {


### PR DESCRIPTION
…resent

Added a new (boolean) variable in challenge services, isSubmitter. This is
true only when Submitter role is present. A condition ng-if
in challenge-tile jade checks if this variable is true. Only then the Complete
 Appeals appears. Test with two different accounts one with role submitter and
one with other roles (copilot) in a challenges that is in appeals phase.