### PR TITLE
Change collapsed notification background to solid color

### DIFF
--- a/assets/css/directives/notification.directive.scss
+++ b/assets/css/directives/notification.directive.scss
@@ -28,7 +28,7 @@
     color: $white;
     font-size: 18px;
     height: 60px;
-    background: linear-gradient(to bottom, silver 0%, gray 35%, #747474 55%, gray 70%, silver 100%);
+    background: $tc-gray-90;
     padding: 0 15px;
     .live{
       margin-right: 12px;


### PR DESCRIPTION
@birdofpreyru I've changed the background color of the collapsed notifications to solid dark grey instead of a gradient.

I've discussed that with Nick Castillo and he approved this change.